### PR TITLE
fix: if A's name in B's name

### DIFF
--- a/lesson.py
+++ b/lesson.py
@@ -27,9 +27,16 @@ class Lesson:
 				result = json.loads(rsp.content.decode("utf-8"))
 				if len(result["data"]) == 0:
 					continue
+				for course in result["data"]:
+					course_id = course["id"]
+					teachers = course["teacherAssignmentList"]
+					teachers = [teacher["person"]["nameZh"] for teacher in teachers]
+					if name in teachers:
+						self.lesson_id.append(course_id)
+						break
 				else:
-					self.lesson_id.append(result["data"][0]["id"])
-					break
+					continue
+				break
 
 	def find_all(self):
 		self.get_lesson_id()


### PR DESCRIPTION
当一个老师的名字被包含于另一个老师的名字时，例如 A 的名字是 XY，B 的名字是 XYZ，此时搜索 A 有一定概率会查找到 B，进而查找失败

本 patch 对这一点进行了修改（尚未进行充分的测试）